### PR TITLE
Always use CRLF for *.txt line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,5 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+*.txt eol=crlf


### PR DESCRIPTION
Problem: Line endings are Unix based when you download the repo as a Zip archive.

Since this repo is for Windows users we always use CRLF for line endings.