### PR TITLE
NTAuthentication and NetType for devlients.txt and Get-NAVDevelopmentClient

### DIFF
--- a/Get-NAVDevelopmentClient.ps1
+++ b/Get-NAVDevelopmentClient.ps1
@@ -42,7 +42,7 @@ function Get-NAVDevelopmentClient
         $ParameterAttribute.ParameterSetName = 'Config'
 
         $ConfigListFileName = Join-Path $PSScriptRoot 'devclients.txt'
-        $Header = 'Name','DevEnvPath','DatabaseServerType','DatabaseServerName','DatabaseName','ZupPath'
+        $Header = 'Name','DevEnvPath','DatabaseServerType','DatabaseServerName','DatabaseName','ZupPath','NTAuthentication','NetType'
         $Configs = Import-Csv -Path $ConfigListFileName -Header $Header | ForEach-Object { $_.Name }
         $ValidateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($Configs)
 
@@ -64,7 +64,7 @@ function Get-NAVDevelopmentClient
         if ($PSCmdlet.MyInvocation.BoundParameters.ConfigName)
         {
             $ConfigListFileName = Join-Path $PSScriptRoot 'devclients.txt'
-            $Header = 'Name','DevEnvPath','DatabaseServerType','DatabaseServerName','DatabaseName','ZupPath'
+            $Header = 'Name','DevEnvPath','DatabaseServerType','DatabaseServerName','DatabaseName','ZupPath','NTAuthentication','NetType'
             $Configs = Import-Csv -Path $ConfigListFileName -Header $Header
             $Config = $Configs | Where-Object Name -eq $PSCmdlet.MyInvocation.BoundParameters.ConfigName
         
@@ -77,6 +77,8 @@ function Get-NAVDevelopmentClient
             $DatabaseServerName = $Config.DatabaseServerName 
             $DatabaseName = $Config.DatabaseName
             $ZupPath = $Config.ZupPath
+            $NTAuthentication = $Config.NTAuthentication
+            $NetType = $Config.NetType
         }
 
         $FilteredClients = Get-FilteredClients -DatabaseServerType $DatabaseServerType -DatabaseServerName $DatabaseServerName -DatabaseName $DatabaseName
@@ -90,6 +92,16 @@ function Get-NAVDevelopmentClient
             if ($ZupPath) 
             { 
                 $Arguments += ('id={0}' -f $ZupPath)  
+            }
+
+            if ($NTAuthentication) 
+            { 
+                $Arguments += ('ntauthentication={0}' -f $NTAuthentication)  
+            }
+
+            if ($NetType)
+            { 
+                $Arguments += ('nettype={0}' -f $NetType)  
             }
 
             $Process = Start-Process -FilePath $Config.DevEnvPath -ArgumentList ($Arguments -join ',') -PassThru

--- a/devclients.txt
+++ b/devclients.txt
@@ -1,3 +1,3 @@
-2015SQL,C:\Program Files (x86)\Microsoft Dynamics NAV\80\RoleTailored Client\finsql.exe,SQL,MACMINI-I\NAVDEMO,Demo Database NAV (8-0),2015
-CRONUS80,C:\Program Files (x86)\Microsoft Dynamics NAV\80\RoleTailored Client\finsql.exe,SQL,JPC-LAPTOP-16\NAVDEMO,Demo Database NAV (8-0),CRONUS80
-CONNECTIT2013,C:\Program Files (x86)\Microsoft Dynamics NAV\70\RoleTailored Client\finsql.exe,SQL,JPC-DEV-03\IDYN,CONNECTIT_2013W1_DEV,CONNECTIT2013
+2015SQL,C:\Program Files (x86)\Microsoft Dynamics NAV\80\RoleTailored Client\finsql.exe,SQL,MACMINI-I\NAVDEMO,Demo Database NAV (8-0),2015,1,tcp
+CRONUS80,C:\Program Files (x86)\Microsoft Dynamics NAV\80\RoleTailored Client\finsql.exe,SQL,JPC-LAPTOP-16\NAVDEMO,Demo Database NAV (8-0),CRONUS80,1,tcp
+CONNECTIT2013,C:\Program Files (x86)\Microsoft Dynamics NAV\70\RoleTailored Client\finsql.exe,SQL,JPC-DEV-03\IDYN,CONNECTIT_2013W1_DEV,CONNECTIT2013,1,tcp


### PR DESCRIPTION
Classic NAV clients have trouble opening the database if you omit the
NTAuthentication and NetType parameter